### PR TITLE
Fix output file path for the hash-jarfiles plugin

### DIFF
--- a/plugin/src/main/java/io/github/adamkorcz/JarfileHashMojo.java
+++ b/plugin/src/main/java/io/github/adamkorcz/JarfileHashMojo.java
@@ -27,12 +27,15 @@ public class JarfileHashMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject project;
 
+    @Parameter(property = "hash-jarfile.outputJsonPath", defaultValue = "")
+    private String outputJsonPath;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             StringBuilder attestations = new StringBuilder();
 
             File targetDir = new File(project.getBasedir(), "target");
-            File outputJson = new File(targetDir, "hash.json");
+            File outputJson = this.getOutputJsonFile(targetDir.getAbsolutePath());
             for (File file : targetDir.listFiles()) {
                 String filePath = file.getAbsolutePath();
                 if (filePath.endsWith(".pom") || filePath.endsWith(".jar")) {
@@ -55,5 +58,24 @@ public class JarfileHashMojo extends AbstractMojo {
             throw new MojoFailureException("Fail to generate hash for the jar files", e);
         }
 
+    }
+
+    private File getOutputJsonFile(String targetDir) {
+        try {
+            if (this.outputJsonPath != null && this.outputJsonPath.length() > 0) {
+                File outputJson = new File(outputJsonPath);
+                if (!outputJson.exists() || !outputJson.isFile()) {
+                    outputJson.getParentFile().mkdirs();
+                    Files.createFile(outputJson.toPath());
+                }
+
+                if (Files.isWritable(outputJson.toPath())) {
+                    return outputJson;
+                }
+            }
+            return new File(targetDir, "hash.json");
+        } catch (IOException e) {
+            return new File(targetDir, "hash.json");
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
                   <configuration>
                       <file>textfile.txt</file>
                       <url>https://s01.oss.sonatype.org/</url>
-                        <repositoryId>io.github.adamkorcz</repositoryId>
+                      <repositoryId>io.github.adamkorcz</repositoryId>
                   </configuration>
               </execution>
           </executions>
@@ -153,6 +153,9 @@
                      </goals>
                  </execution>
              </executions>
+             <configuration>
+                 <outputJsonPath>${SLSA_OUTPUTS_ARTIFACTS_FILE}</outputJsonPath>
+             </configuration>
          </plugin><!--
          <plugin>
             <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This PR fix the logic of the plugin by reading the output path from the configuration parameters if exists. Otherwise the default output path target/hash.json is used. User of the plugin need to specify the path in the correct configuration parameter when applying the plugin, the value could be input manually or using ${XXX} to call environment variable. But maven build in general will not take any system environment parameter, so in order to include them, a -D option is needed. So in the example, running `mvn -DSLSA_OUTPUTS_ARTIFACTS_FILE=$SLSA_OUTPUTS_ARTIFACTS_FILE clean package` or `mvn -DSLSA_OUTPUTS_ARTIFACTS_FILE=/custom/path clean package` will work. The prior one will require pre-defined of the system environment variable.