### PR TITLE
Add flag for plugin run

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.github.adamkorcz</groupId>
+    <groupId>dev.slsa.slsaframework</groupId>
     <artifactId>hash-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <version>0.0.1</version>

--- a/plugin/src/main/java/io/github/adamkorcz/JarfileHashMojo.java
+++ b/plugin/src/main/java/io/github/adamkorcz/JarfileHashMojo.java
@@ -30,7 +30,17 @@ public class JarfileHashMojo extends AbstractMojo {
     @Parameter(property = "hash-jarfile.outputJsonPath", defaultValue = "")
     private String outputJsonPath;
 
+    @Parameter(property = "run.hash.jarfile", defaultValue = "false")
+    private Boolean runHashJarfile;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!runHashJarfile) {
+            getLog().info("Hash Jarfile plugin is skipped.");
+            return;
+        }
+
+        getLog().info("Start running hash Jarfile plugin.");
+
         try {
             StringBuilder attestations = new StringBuilder();
 
@@ -58,6 +68,7 @@ public class JarfileHashMojo extends AbstractMojo {
             throw new MojoFailureException("Fail to generate hash for the jar files", e);
         }
 
+        getLog().info("Finish running hash Jarfile plugin.");
     }
 
     private File getOutputJsonFile(String targetDir) {


### PR DESCRIPTION
Add flag to the maven plugin.
To install the plugin
```
cd plugin
mvn clean install
cd ..
```

To build the project and skip the plugin
```
mvn clean package
```

To build the project and run the plugin
```
mvn clean package -Drun.hash.jarfile
```
or
```
mvn clean package -Drun.hash.jarfile=true
```

The flag name `run.hash.jarfile` is set in line 33 with the property parameter. It is a general convention to add in as detail as possible as we don't want same name for different plugin or dependencies.