### PR TITLE
Apply main class manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,12 @@ java {
     withJavadocJar()
 }
 
+tasks.withType<Jar> {
+    manifest {
+        attributes["Main-Class"] = "hello.HelloWorld"
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("maven") {


### PR DESCRIPTION
The change is for kotlin version build.gradle.kts. If it is meant for groovy version build.gradle, then use the following instead.
```
jar {
    manifest {
        attributes 'Main-Class': 'hello.HelloWorld'
    }
}
```